### PR TITLE
classpath files

### DIFF
--- a/com.thoughtworks.qdox/.classpath
+++ b/com.thoughtworks.qdox/.classpath
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <classpathentry exported="true" kind="lib" path=""/>
 </classpath>

--- a/com.thoughtworks.qdox/META-INF/MANIFEST.MF
+++ b/com.thoughtworks.qdox/META-INF/MANIFEST.MF
@@ -14,6 +14,6 @@ Export-Package: com.thoughtworks.qdox,
  com.thoughtworks.qdox.parser.impl,
  com.thoughtworks.qdox.parser.structs,
  com.thoughtworks.qdox.tools
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: com.thoughtworks.qdox

--- a/de.flexiprovider/.classpath
+++ b/de.flexiprovider/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry exported="true" kind="lib" path="libs/FlexiProvider-1.7p7.signed.jar" sourcepath="/3rdPartySource/FlexiProvider-1.7p7_src.zip"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/de.flexiprovider/META-INF/MANIFEST.MF
+++ b/de.flexiprovider/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
  src/de/flexiprovider/,
  libs/FlexiProvider-1.7p7.signed.jar
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.core.logging.utils,
  org.jcryptool.core.operations.providers
 Export-Package: de.flexiprovider,

--- a/net.sourceforge.codec/.classpath
+++ b/net.sourceforge.codec/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="" sourcepath="/3rdPartySource/CoDec-build21-jdk13_src.zip">
 		<attributes>

--- a/net.sourceforge.codec/META-INF/MANIFEST.MF
+++ b/net.sourceforge.codec/META-INF/MANIFEST.MF
@@ -17,6 +17,6 @@ Export-Package: codec,
  codec.x501,
  codec.x509,
  codec.x509.extensions
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: net.sourceforge.codec

--- a/net.sourceforge.ehep.nl_de/.classpath
+++ b/net.sourceforge.ehep.nl_de/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.ehep.nl_de/META-INF/MANIFEST.MF
+++ b/net.sourceforge.ehep.nl_de/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Hex Editor Plugin NL German
 Bundle-SymbolicName: net.sourceforge.ehep.nl_de;singleton:=true
 Bundle-Version: 1.0.0
 Fragment-Host: net.sourceforge.ehep;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: jcryptool.org
 Automatic-Module-Name: net.sourceforge.ehep.nl_de
 Export-Package: net.sourceforge.ehep.editors,

--- a/net.sourceforge.ehep/.classpath
+++ b/net.sourceforge.ehep/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.ehep/META-INF/MANIFEST.MF
+++ b/net.sourceforge.ehep/META-INF/MANIFEST.MF
@@ -13,6 +13,6 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Export-Package: net.sourceforge.ehep,net.sourceforge.ehep.actions,net.sourceforge.ehep.core,net.sourceforge.ehep.editors,net.sourceforge.ehep.events,net.sourceforge.ehep.gui,net.sourceforge.ehep.popup.actions,net.sourceforge.ehep.preferences
 Bundle-ManifestVersion: 2
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.core.logging.utils
 Automatic-Module-Name: net.sourceforge.ehep

--- a/org.apache.commons.cli/.classpath
+++ b/org.apache.commons.cli/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="">
 		<attributes>

--- a/org.apache.commons.cli/META-INF/MANIFEST.MF
+++ b/org.apache.commons.cli/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Bundle-Name: %Bundle-Name
 Bundle-DocURL: http://commons.apache.org/cli/
 Bundle-ManifestVersion: 2
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: org.apache.commons.cli;singleton:=true
 Tool: Bnd-0.0.238
 Bundle-ActivationPolicy: lazy

--- a/org.bouncycastle/.classpath
+++ b/org.bouncycastle/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry exported="true" kind="lib" path="libs/bcprov-jdk15on-162.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.bouncycastle/META-INF/MANIFEST.MF
+++ b/org.bouncycastle/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.bouncycastle.BouncyCastlePlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  src/org/bouncycastle/,
  libs/bcprov-jdk15on-162.jar

--- a/org.jcryptool.actions.core/.classpath
+++ b/org.jcryptool.actions.core/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.jcryptool.actions.core/META-INF/MANIFEST.MF
+++ b/org.jcryptool.actions.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jcryptool.actions.core;singleton:=true
 Bundle-Version: 1.0.0
 Bundle-Vendor: %BundleVendor
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jcryptool.actions.core,
  org.jcryptool.actions.core.registry,

--- a/org.jcryptool.actions.ui/.classpath
+++ b/org.jcryptool.actions.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.actions.ui/META-INF/MANIFEST.MF
+++ b/org.jcryptool.actions.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.ui,
  org.jcryptool.crypto.keystore;bundle-version="1.0.0",
  de.flexiprovider;bundle-version="1.7.0",
  org.jcryptool.core;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.filesystem,
  org.jcryptool.actions.core.registry,

--- a/org.jcryptool.commands.core/.classpath
+++ b/org.jcryptool.commands.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.commands.core/META-INF/MANIFEST.MF
+++ b/org.jcryptool.commands.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.jcryptool.commands.core;singleton:=true
 Bundle-Version: 1.0.0
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jcryptool.commands.core,
  org.jcryptool.commands.core.api,

--- a/org.jcryptool.commands.ui/.classpath
+++ b/org.jcryptool.commands.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.commands.ui/META-INF/MANIFEST.MF
+++ b/org.jcryptool.commands.ui/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jface.text,
  org.eclipse.ui.console,
  org.apache.commons.cli;bundle-version="1.2.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: org.jcryptool.commands.core.evaluator,
  org.jcryptool.core.logging.utils,

--- a/org.jcryptool.core.cryptosystem/.classpath
+++ b/org.jcryptool.core.cryptosystem/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.core.cryptosystem/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core.cryptosystem/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.jcryptool.core.cryptosystem.CryptosystemPlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.jcryptool.core.cryptosystem,
  org.jcryptool.core.cryptosystem.core,
  org.jcryptool.core.cryptosystem.core.exception,

--- a/org.jcryptool.core.help/.classpath
+++ b/org.jcryptool.core.help/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.jcryptool.core.help/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core.help/META-INF/MANIFEST.MF
@@ -4,4 +4,4 @@ Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jcryptool.core.help;singleton:=true
 Bundle-Version: 1.0.0
 Bundle-Vendor: %bundleVendor
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.jcryptool.core.logging/.classpath
+++ b/org.jcryptool.core.logging/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.core.logging/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core.logging/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0
 Bundle-Activator: org.jcryptool.core.logging.LoggingPlugin
 Bundle-Vendor: %bundleProvider
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui
 Automatic-Module-Name: org.jcryptool.core.logging

--- a/org.jcryptool.core.nl/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core.nl/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: org.jcryptool.core.nl;singleton:=true
 Bundle-Version: 1.0.0
 Bundle-Vendor: %bundleProvider
 Fragment-Host: org.jcryptool.core;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.jcryptool.core.operations/.classpath
+++ b/org.jcryptool.core.operations/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.core.operations/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core.operations/META-INF/MANIFEST.MF
@@ -31,7 +31,7 @@ Export-Package: org.jcryptool.core.operations,
  org.jcryptool.core.operations.providers,
  org.jcryptool.core.operations.providers.preferences,
  org.jcryptool.core.operations.util
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.actions.core.registry,
  org.jcryptool.actions.core.types,
  org.jcryptool.core.logging.utils,

--- a/org.jcryptool.core.util/.classpath
+++ b/org.jcryptool.core.util/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.core.util/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core.util/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.core.resources,
  org.jcryptool.core.logging;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jcryptool.core.util,
  org.jcryptool.core.util.calendar,

--- a/org.jcryptool.core.views/.classpath
+++ b/org.jcryptool.core.views/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.core.views/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core.views/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Export-Package: org.jcryptool.core.views;
  org.jcryptool.core.views.content.palette,
  org.jcryptool.core.views.content.structure,
  org.jcryptool.core.views.content.tree
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.core,
  org.jcryptool.core.actions,
  org.jcryptool.core.logging.utils,

--- a/org.jcryptool.core/.classpath
+++ b/org.jcryptool.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.core/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jcryptool.core.operations;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %bundleProvider
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.jcryptool.core,
  org.jcryptool.core.actions,
  org.jcryptool.core.commands,

--- a/org.jcryptool.crypto.flexiprovider.algorithms/.classpath
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.crypto.flexiprovider.algorithms/META-INF/MANIFEST.MF
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Export-Package: org.jcryptool.crypto.flexiprovider.algorithms,
  org.jcryptool.crypto.flexiprovider.algorithms.ui.wizards.blockcipher,
  org.jcryptool.crypto.flexiprovider.algorithms.ui.wizards.securerandom,
  org.jcryptool.crypto.flexiprovider.algorithms.ui.wizards.signature
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.core.logging.utils,
  org.jcryptool.crypto.flexiprovider.algorithms.listeners,
  org.jcryptool.crypto.flexiprovider.descriptors.algorithms,

--- a/org.jcryptool.crypto.flexiprovider.engines/.classpath
+++ b/org.jcryptool.crypto.flexiprovider.engines/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.crypto.flexiprovider.engines/META-INF/MANIFEST.MF
+++ b/org.jcryptool.crypto.flexiprovider.engines/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  de.flexiprovider;bundle-version="1.7.0",
  org.jcryptool.crypto.keystore;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.actions.core.registry,
  org.jcryptool.actions.core.types,
  org.jcryptool.core.logging.dialogs,

--- a/org.jcryptool.crypto.flexiprovider.integrator/.classpath
+++ b/org.jcryptool.crypto.flexiprovider.integrator/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.crypto.flexiprovider.integrator/META-INF/MANIFEST.MF
+++ b/org.jcryptool.crypto.flexiprovider.integrator/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  de.flexiprovider;bundle-version="1.7.0",
  org.jcryptool.crypto.flexiprovider.keystore;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.jcryptool.crypto.flexiprovider.integrator.IntegratorPlugin
 Bundle-Vendor: %bundleProvider

--- a/org.jcryptool.crypto.flexiprovider.keystore/.classpath
+++ b/org.jcryptool.crypto.flexiprovider.keystore/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.crypto.flexiprovider.keystore/META-INF/MANIFEST.MF
+++ b/org.jcryptool.crypto.flexiprovider.keystore/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.core.runtime,
  de.flexiprovider;bundle-version="1.7.0",
  org.jcryptool.crypto.keystore;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.core.logging.utils,
  org.jcryptool.core.util.directories,
  org.jcryptool.crypto.flexiprovider.descriptors.meta.interfaces,

--- a/org.jcryptool.crypto.flexiprovider.operations/.classpath
+++ b/org.jcryptool.crypto.flexiprovider.operations/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.crypto.flexiprovider.operations/META-INF/MANIFEST.MF
+++ b/org.jcryptool.crypto.flexiprovider.operations/META-INF/MANIFEST.MF
@@ -32,7 +32,7 @@ Export-Package: org.jcryptool.crypto.flexiprovider.operations,
  org.jcryptool.crypto.flexiprovider.operations.xml.io,
  org.jcryptool.crypto.flexiprovider.operations.xml.keys,
  org.jcryptool.crypto.flexiprovider.operations.xml.ops
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.core.logging.dialogs,
  org.jcryptool.core.logging.utils,
  org.jcryptool.core.operations,

--- a/org.jcryptool.crypto.flexiprovider/.classpath
+++ b/org.jcryptool.crypto.flexiprovider/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.crypto.flexiprovider/META-INF/MANIFEST.MF
+++ b/org.jcryptool.crypto.flexiprovider/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Export-Package: org.jcryptool.crypto.flexiprovider,
  org.jcryptool.crypto.flexiprovider.ui.nodes,
  org.jcryptool.crypto.flexiprovider.ui.perspective,
  org.jcryptool.crypto.flexiprovider.xml
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jcryptool.core.logging.utils,
  org.jcryptool.crypto.keystore.keys
 Automatic-Module-Name: org.jcryptool.crypto.flexiprovider

--- a/org.jcryptool.crypto.keystore/.classpath
+++ b/org.jcryptool.crypto.keystore/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="lib" path="swt-grouplayout.jar" sourcepath="swt-grouplayout.zip"/>

--- a/org.jcryptool.crypto.keystore/META-INF/MANIFEST.MF
+++ b/org.jcryptool.crypto.keystore/META-INF/MANIFEST.MF
@@ -41,7 +41,7 @@ Import-Package: org.jcryptool.core.logging.dialogs,
  org.jcryptool.core.operations.util,
  org.jcryptool.core.util.directories,
  org.jcryptool.core.util.ui
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .,
  swt-grouplayout.jar
 Automatic-Module-Name: org.jcryptool.crypto.keystore

--- a/org.jcryptool.crypto.keystore/META-INF/MANIFEST.MF
+++ b/org.jcryptool.crypto.keystore/META-INF/MANIFEST.MF
@@ -9,7 +9,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.filesystem,
  net.sourceforge.codec;bundle-version="1.7.0",
- de.flexiprovider;bundle-version="1.7.0"
+ de.flexiprovider;bundle-version="1.7.0",
+ javax.xml.bind,
+ com.sun.xml.bind
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jcryptool.crypto.keystore,
  org.jcryptool.crypto.keystore.backend,

--- a/org.jcryptool.editor.hex/.classpath
+++ b/org.jcryptool.editor.hex/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.editor.hex/META-INF/MANIFEST.MF
+++ b/org.jcryptool.editor.hex/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: JCrypTool Hex Editor Extensions
 Bundle-SymbolicName: org.jcryptool.editor.hex;singleton:=true
 Bundle-Version: 1.0.0
 Fragment-Host: net.sourceforge.ehep;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.core.filesystem,
  org.jcryptool.core.logging.utils,
  org.jcryptool.core.operations.editors,

--- a/org.jcryptool.editor.text/.classpath
+++ b/org.jcryptool.editor.text/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.editor.text/META-INF/MANIFEST.MF
+++ b/org.jcryptool.editor.text/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jface.text,
  org.eclipse.core.filesystem
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.jcryptool.editor.text,
  org.jcryptool.editor.text.commands,
  org.jcryptool.editor.text.editor,

--- a/org.jcryptool.fileexplorer/.classpath
+++ b/org.jcryptool.fileexplorer/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.fileexplorer/META-INF/MANIFEST.MF
+++ b/org.jcryptool.fileexplorer/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.ui.model.workbench,
  org.eclipse.e4.core.commands,
  org.jcryptool.core.operations;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.core.filesystem,
  org.jcryptool.core,
  org.jcryptool.core.logging.utils,

--- a/org.jcryptool.product/jcryptool.product
+++ b/org.jcryptool.product/jcryptool.product
@@ -42,6 +42,7 @@
    <intro introId="org.jcryptool.intro"/>
 
    <vm>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
    </vm>
 
    <license>

--- a/org.jcryptool.releng/pom.xml
+++ b/org.jcryptool.releng/pom.xml
@@ -35,7 +35,7 @@ Maven 3 and Java 8 are required for the build. See https://github.com/jcryptool/
 		<tycho.version>1.4.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
+		<java.version>1.11</java.version>
 		<product.id>jcryptool</product.id>
 		<product.version>1.0.0</product.version>
 		<timestamp>${maven.build.timestamp}</timestamp>

--- a/org.jcryptool.target/org.jcryptool.target.target
+++ b/org.jcryptool.target/org.jcryptool.target.target
@@ -22,6 +22,8 @@
 		<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
 		<unit id="javax.xml.soap" version="1.3.0.v201105210645"/>
 		<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
+		<unit id="com.sun.xml.bind" version="2.2.0.v201505121915"/>
+		<unit id="com.sun.xml.bind.source" version="2.2.0.v201505121915"/>
 	</location>
 </locations>
 <launcherArgs>

--- a/org.jcryptool.target/org.jcryptool.target.target
+++ b/org.jcryptool.target/org.jcryptool.target.target
@@ -17,6 +17,12 @@
 		<unit id="org.eclipse.zest.sdk.feature.group" version="1.7.0.201606061308"/>
 		<unit id="org.eclipse.platform.feature.group" version="4.12.0.v20190605-1801"/>
 	</location>
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository"/>
+		<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+		<unit id="javax.xml.soap" version="1.3.0.v201105210645"/>
+		<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
+	</location>
 </locations>
 <launcherArgs>
 <vmArgs>-Xms40m -Xmx512m</vmArgs>

--- a/org.jcryptool.webbrowser/.classpath
+++ b/org.jcryptool.webbrowser/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jcryptool.webbrowser/META-INF/MANIFEST.MF
+++ b/org.jcryptool.webbrowser/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jcryptool.webbrowser;singleton:=true
 Bundle-Version: 1.0.0
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.jcryptool.webbrowser.BrowserPlugin
 Bundle-Vendor: %bundleProvider

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/BrowserPlugin.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/BrowserPlugin.java
@@ -20,7 +20,6 @@ public class BrowserPlugin extends AbstractUIPlugin {
     /** The plug-in ID. */
     public static final String PLUGIN_ID = "org.jcryptool.webbrowser"; //$NON-NLS-1$
 
-    
     /**
      * Returns an image descriptor for the image file at the given plug-in relative path
      *

--- a/org.jdom/.classpath
+++ b/org.jdom/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path=""/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.jdom/META-INF/MANIFEST.MF
+++ b/org.jdom/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.jdom;singleton:=true
 Bundle-Version: 1.1.1
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.jdom,
  org.jdom.adapters,
  org.jdom.filter,


### PR DESCRIPTION
your commits did not seem to catch the .classpath files in migrating to java 11 because they are ignored by default. Maybe we should change that, anyhow, please merge so we don't miss that on future checkouts.